### PR TITLE
extend base Symfony Command class

### DIFF
--- a/Command/SwooleBridgeServerCommand.php
+++ b/Command/SwooleBridgeServerCommand.php
@@ -3,6 +3,7 @@
 namespace Insidestyles\SwooleBridgeBundle\Command;
 
 use Insidestyles\SwooleBridge\Handler;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -10,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Class SwooleBridgeServerCommand
  * @package Insidestyles\SwooleBridgeBundle\Command
  */
-final class SwooleBridgeServerCommand
+final class SwooleBridgeServerCommand extends Command
 {
     /**
      * @var Handler
@@ -29,6 +30,7 @@ final class SwooleBridgeServerCommand
 
     public function __construct(Handler $handler, string $host, int $port)
     {
+        parent::__construct();
         $this->handler = $handler;
         $this->host    = $host;
         $this->port    = $port;


### PR DESCRIPTION
Now that I've updated my app to newer Symfony version it started to complain about not extending the base `Command` class. Should have been added when removing `ContainerAwareCommand` some time ago.


The error, which is thrown only in `Symfony >= 3.3` ([the compiler pass](https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php) doesn't exist in lower branches):
```
In AddConsoleCommandPass.php line 56:
                                                                                                                                          
  The service "swoole_bridge.server_command" tagged "console.command" must be a subclass of "Symfony\Component\Console\Command\Command".
```