### PR TITLE
configuration class updated for symfony 5

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,8 +18,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('swoole_bridge');
+        $treeBuilder = new TreeBuilder('swoole_bridge');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
_\Symfony\Component\Config\Definition\Builder\TreeBuilder_ was changed in symfony 5